### PR TITLE
Silta v1.0 components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  silta: silta/silta@0.1
+  silta: silta/silta@1
 
 executors:
   cicd80:

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Nginx container.
-FROM wunderio/silta-nginx:latest
+FROM wunderio/silta-nginx:1.17-v1
 
 COPY . /app/web

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the PHP container.
-FROM wunderio/silta-php-fpm:8.0-fpm-v0.1
+FROM wunderio/silta-php-fpm:8.0-fpm-v1
 
 COPY --chown=www-data:www-data . /app

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Shell container.
-FROM wunderio/silta-php-shell:php8.0-v0.1
+FROM wunderio/silta-php-shell:php8.0-v1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
Silta component adjustments to use v1.0 tags. There are no functional changes in this PR, 
image tags are pointed to the same images as before, but with v1.0 tags. 
From now on, Silta will aim to follow semantic versioning practices.
More information here: https://github.com/wunderio/silta/releases/tag/2023-10-03

Please review adjusted image tags and make sure this PR only changes relevant 
configuration files, feel free to make changes for components that have been left 
out from this PR.

This pull request was created with https://github.com/wunderio/internal-mass-updater.