### PR TITLE
Replace deprecated silta-cicd v0 images with v1 ones

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   cicd80:
     docker:
-      - image: wunderio/silta-cicd:circleci-php8.0-node16-composer2-v0.1
+      - image: wunderio/silta-cicd:circleci-php8.0-node16-composer2-v1
 
 workflows:
   version: 2


### PR DESCRIPTION
This PR aims to replace the usage of deprecated silta-cicd v0.x images with the closest equivalent of silta-cicd v1.x images.

The v0.x images are deprecated and no longer maintained. Even the image tags that are not ending with a version number should be replaced, as they part of the old v0.x naming scheme. 

Notable differences between the v0.x and v1.x images are the tools that are included by default. The v1.x images do no longer include:
- Gcloud CLI
- Azure CLI
- OAuth2l

Please review adjusted image tags and make sure this PR only changes relevant configuration files.

This pull request was created with https://github.com/wunderio/internal-mass-updater.